### PR TITLE
Fixes from today's testing

### DIFF
--- a/build-server-0.1-openssl.sh
+++ b/build-server-0.1-openssl.sh
@@ -1,12 +1,24 @@
 #!/bin/bash
+echo "Build server script v0.1d"
 
 # OpenSSL dependencies
 sudo apt-get install -y make gcc
 
-# Clone Repos
+# Go get the source
 git clone https://forge.etsi.org/gerrit/CYBER.MSP-OpenSSL
 
-cd ~/CYBER.MSP-OpenSSL
+# Build and install it
+cd CYBER.MSP-OpenSSL
 ./config
 make
 sudo make install
+
+if [ "$1" != "local" ]
+then
+    # For Azure builds, put this somewhere less obscure
+    cd ../
+    mkdir /opt/middlebox-test-environment
+    cp -R * /opt/middlebox-test-environment
+    chown -R azureuser:azureuser /opt/middlebox-test-environment/*
+    chmod -R +rw /opt/middlebox-test-environment/*
+fi


### PR DESCRIPTION
In build-server:
- Alter cd command such that it doesn't only work in the user's home directory
- Added an conditional extra step that moves the output from the build stage to /opt/<somewhere>/ for the Azure builds (can be skipped by specifying "local" as an argument)

In build-azure
- Rationalised the script namess o that they match
- Put the VM size and storage SKU names in variables as part of an unsuccessful attempt to run it outside of centralus
- Fixed a bug where Get-Content returns an array of strings when reading a public key file, and kills Add-AzureRmVMSshPublicKey as a result
- Promptly commented that whole line out to allow for password access instead of ssh key access, to allow us to pre-build a number of VMs for the hackathon
- Changed the default password to one approved by our friendly neighbourhood cyber-security experts